### PR TITLE
Changed dropdown from experimental hover syntax to regular one.

### DIFF
--- a/lona_picocss/templates/picocss/header.html
+++ b/lona_picocss/templates/picocss/header.html
@@ -8,13 +8,15 @@
             {% if isinstance(target, str) %}
                 <li><a href="{{ resolve_url(Lona, target) }}">{{ label }}</a></li>
             {% elif isinstance(target, list) %}
-                <li role="list" dir="rtl">
-                    <a href="#" aria-haspopup="listbox">{{ label }}</a>
-                    <ul role="listbox">
-                        {% for sub_label, sub_target in target %}
-                            <li><a href="{{ resolve_url(Lona, sub_target) }}">{{ sub_label }}</a></li>
-                        {% endfor %}
-                    </ul>
+                <li>
+                    <details role="list" dir="rtl">
+                        <summary aria-haspopup="listbox" role="link">{{ label }}</summary>
+                        <ul role="listbox">
+                            {% for sub_label, sub_target in target %}
+                                <li><a href="{{ resolve_url(Lona, sub_target) }}">{{ sub_label }}</a></li>
+                            {% endfor %}
+                        </ul>
+                    </details>
                 </li>
             {% endif %}
         {% endfor %}


### PR DESCRIPTION
The currently used Pico.css dropdowns, which open on hover, lead to problems on older iOS Safari browsers (Test device: iPhone SE, iOS 14), where they cannot be closed by tapping outside them. Also, clicking at the dropdown summary, which is a `href="#"` reloads the current page, which makes no sense.

This change proposes using the regular Pico.css dropdown syntax, which works fine also on mobile Safari.