### PR TITLE
Update theme.css

### DIFF
--- a/lona_picocss/templates/picocss/theme.css
+++ b/lona_picocss/templates/picocss/theme.css
@@ -12,7 +12,7 @@ body {
 }
 
 main#lona {
-    min-height: 100%;
+    height: 100%;
 }
 
 footer#lona-footer {


### PR DESCRIPTION
`min-height` on main#lona seems to have no effect when using Firefox. (Maybe related to https://stackoverflow.com/questions/14053206/css-min-height-not-working-on-mozilla-firefox)

`height` OTOH works as intended.